### PR TITLE
block invalid branch names

### DIFF
--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -116,6 +116,14 @@ class Commiter:
         shell.execute("git config --replace-all user.email " + email)
 
     @staticmethod
+    def checkbranchname(branchname):
+        exitcode = shell.execute("git check-ref-format --normalize refs/heads/" + branchname)
+        if exitcode is 0:
+            return True
+        else:
+            return False
+
+    @staticmethod
     def branch(branchname):
         branchexist = shell.execute("git show-ref --verify --quiet refs/heads/" + branchname)
         if branchexist is 0:

--- a/migration.py
+++ b/migration.py
@@ -116,6 +116,23 @@ def parsecommandline():
     configuration.setconfigfile(arguments.configfile)
 
 
+def validate():
+    config = configuration.get()
+    streamname = config.streamname
+    branchname = streamname + "_branchpoint"
+    previousstreamname = config.previousstreamname
+    offendingbranchname = None
+    if not Commiter.checkbranchname(streamname):
+        offendingbranchname = streamname
+    elif not Commiter.checkbranchname(branchname):
+        offendingbranchname = branchname
+    elif not Commiter.checkbranchname(previousstreamname):
+        offendingbranchname = previousstreamname
+    if offendingbranchname:
+        sys.exit(offendingbranchname + " is not a valid git branch name - consider renaming the stream")
+
+
 if __name__ == "__main__":
     parsecommandline()
+    validate()
     migrate()

--- a/tests/test_gitFunctions.py
+++ b/tests/test_gitFunctions.py
@@ -174,6 +174,18 @@ class GitFunctionsTestCase(unittest.TestCase):
                 self.assertEqual(jar, lines[0].strip())
                 self.assertEqual(zip, lines[1].strip())
 
+    def test_checkbranchname_expect_valid(self):
+        with testhelper.createrepo(folderprefix="gitfunctionstestcase_"):
+            self.assertEqual(True, Commiter.checkbranchname("master"), "master should be a valid branch name")
+
+    def test_checkbranchname_quoted_expect_invalid(self):
+        with testhelper.createrepo(folderprefix="gitfunctionstestcase_"):
+            self.assertEqual(False, Commiter.checkbranchname("'master pflaster'"), "'master pflaster' should not be a valid branch name")
+
+    def test_checkbranchname_unquoted_expect_invalid(self):
+        with testhelper.createrepo(folderprefix="gitfunctionstestcase_"):
+            self.assertEqual(False, Commiter.checkbranchname("master pflaster"), "master pflaster should not be a valid branch name")
+
     def simulateCreationAndRenameInGitRepo(self, originalfilename, newfilename):
         open(originalfilename, 'a').close()  # create file
         Initializer.initialcommit()


### PR DESCRIPTION
If a stream name would lead to invalid git branch names, abort the migration and suggest renaming the stream.
Fixes #51.