### PR TITLE
handle relative file names in tests

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,6 +4,7 @@ import os
 from configuration import Builder
 import configuration
 import shell
+from tests import testhelper
 
 
 class ConfigurationTestCase(unittest.TestCase):
@@ -39,7 +40,7 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertTrue(config.useautomaticconflictresolution)
 
     def test_getSampleConfig_ExpectInitializedConfigWithDefaultValues(self):
-        config = configuration.read("../config.ini.sample")
+        config = configuration.read(testhelper.getrelativefilename("../config.ini.sample"))
         self.assertEqual("lscm", config.scmcommand)
         self.assertEqual(config, configuration.get())
 
@@ -63,14 +64,14 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(['.zip', '.jar', '.exe'], config.ignorefileextensions)
 
     def test_read_passedin_configfile(self):
-        self._assertTestConfig(configuration.read('resources/test_config.ini'))
+        self._assertTestConfig(configuration.read(testhelper.getrelativefilename('resources/test_config.ini')))
 
     def test_read_configfile_from_configuration(self):
-        configuration.setconfigfile('resources/test_config.ini')
+        configuration.setconfigfile(testhelper.getrelativefilename('resources/test_config.ini'))
         self._assertTestConfig(configuration.read())
 
     def test_read_minimumconfigfile_shouldrelyonfallbackvalues(self):
-        configuration.setconfigfile('resources/test_minimum_config.ini')
+        configuration.setconfigfile(testhelper.getrelativefilename('resources/test_minimum_config.ini'))
         self._assertDefaultConfig(configuration.read())
 
     def _assertTestConfig(self, config):

--- a/tests/test_gitFunctions.py
+++ b/tests/test_gitFunctions.py
@@ -117,7 +117,7 @@ class GitFunctionsTestCase(unittest.TestCase):
             self.assertFalse(Commiter.copybranch("master", branchname) is 0)
 
     def test_splitoutputofgitstatusz(self):
-        with open('./resources/test_ignore_git_status_z.txt', 'r') as file:
+        with open(testhelper.getrelativefilename('./resources/test_ignore_git_status_z.txt'), 'r') as file:
             repositoryfiles = Commiter.splitoutputofgitstatusz(file.readlines())
             self.assertEqual(12, len(repositoryfiles))
             self.assertEqual('project1/src/tobedeleted.txt', repositoryfiles[0])
@@ -134,13 +134,13 @@ class GitFunctionsTestCase(unittest.TestCase):
             self.assertEqual('project1/src/sub/klingklong.zip', repositoryfiles[11])
 
     def test_splitoutputofgitstatusz_filterprefix_A(self):
-        with open('./resources/test_ignore_git_status_z.txt', 'r') as file:
+        with open(testhelper.getrelativefilename('./resources/test_ignore_git_status_z.txt'), 'r') as file:
             repositoryfiles = Commiter.splitoutputofgitstatusz(file.readlines(), 'A  ')
             self.assertEqual(1, len(repositoryfiles))
             self.assertEqual('project1/src/tobedeleted.txt', repositoryfiles[0])
 
     def test_splitoutputofgitstatusz_filterprefix_double_question(self):
-        with open('./resources/test_ignore_git_status_z.txt', 'r') as file:
+        with open(testhelper.getrelativefilename('./resources/test_ignore_git_status_z.txt'), 'r') as file:
             repositoryfiles = Commiter.splitoutputofgitstatusz(file.readlines(), '?? ')
             self.assertEqual(7, len(repositoryfiles))
             self.assertEqual('project1/src/sub/kling -- klong.zip', repositoryfiles[0])

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -47,3 +47,25 @@ def cd(newdir):
         yield
     finally:
         os.chdir(previousdir)
+
+
+def getrelativefilename(filenamerelativetotests):
+    """
+    Determine the correct relative file name, depending on the test runtime environment.
+    Default environment ist PyCharm, which sets the working directory to /test.
+    However, if the tests are run with 'python3 -m unittest discover -s tests', the working directory is one level above.
+
+    :param filenamerelativetotests:
+    :return:the correct relative file name
+    """
+    dir = os.getcwd()
+    if dir.endswith("/tests"):
+        relativefilename = filenamerelativetotests
+    else:
+        if filenamerelativetotests.startswith("../"):
+            relativefilename = filenamerelativetotests[1:]
+        elif filenamerelativetotests.startswith("./"):
+            relativefilename = 'tests/' + filenamerelativetotests[2:]
+        else:
+            relativefilename = 'tests/' + filenamerelativetotests
+    return relativefilename


### PR DESCRIPTION
All tests now pass if run from the git directory as follows:
  python3 -m unittest discover -s tests
Relative file names now work for both PyCharm and command line test suites.