### PR TITLE
.jazzignore <-> .gitignore

### DIFF
--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -236,13 +236,10 @@ class Commiter:
             if not line.startswith("#"):
                 line = line.strip()
                 if line.startswith("core.ignore"):
-                    gitignorelines.append('\n')
-                    if line.startswith("core.ignore.recursive"):
-                        recursive = True
-                    else:
-                        recursive = False
+                    gitignorelines.append(os.linesep)
+                    recursive = line.startswith("core.ignore.recursive")
                 for foundpattern in Commiter.findignorepatternregex.findall(line):
-                    gitignoreline = foundpattern + '\n'
+                    gitignoreline = foundpattern + os.linesep
                     if not recursive:
                         gitignoreline = '/' + gitignoreline    # forward, not os.sep
                     gitignorelines.append(gitignoreline)

--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -60,6 +60,7 @@ class Initializer:
 class Commiter:
     commitcounter = 0
     isattachedtoaworkitemregex = re.compile("^\d*:.*-")
+    findignorepatternregex = re.compile("\{([^\{\}]*)\}")
 
     @staticmethod
     def addandcommit(changeentry):
@@ -213,6 +214,26 @@ class Commiter:
                             repositoryfile = entry       # file on a single line (e.g. rename continuation)
                         repositoryfiles.append(repositoryfile)
         return repositoryfiles
+
+    @staticmethod
+    def translatejazzignore(jazzignorelines):
+        recursive = False
+        gitignorelines = []
+        for line in jazzignorelines:
+            if not line.startswith("#"):
+                line = line.strip()
+                if line.startswith("core.ignore"):
+                    gitignorelines.append('\n')
+                    if line.startswith("core.ignore.recursive"):
+                        recursive = True
+                    else:
+                        recursive = False
+                for foundpattern in Commiter.findignorepatternregex.findall(line):
+                    gitignoreline = foundpattern + '\n'
+                    if not recursive:
+                        gitignoreline = '/' + gitignoreline
+                    gitignorelines.append(gitignoreline)
+        return gitignorelines
 
 
 class Differ:

--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -251,23 +251,30 @@ class Commiter:
     @staticmethod
     def ignorejazzignore(repositoryfiles):
         """
-        if a .jazzignore file is modified, translate it to .gitignore
+        If a .jazzignore file is modified or added, translate it to .gitignore,
+        if a .jazzignore file is deleted, delete the corresponding .gitignore file as well.
 
         :param repositoryfiles: the modified files
         """
         jazzignore = ".jazzignore"
+        jazzignorelen = len(jazzignore)
         for repositoryfile in repositoryfiles:
-            jazzignorelen = len(jazzignore)
             if repositoryfile[-jazzignorelen:] == jazzignore:
-                jazzignorelines = []
-                with open(repositoryfile, 'r') as jazzignorefile:
-                    jazzignorelines = jazzignorefile.readlines()
-                if len(jazzignorelines) > 0:
-                    path = repositoryfile[0:len(repositoryfile)-jazzignorelen]
-                    gitignore = path + ".gitignore"
-                    # overwrite in any case
-                    with open(gitignore, 'w') as gitignorefile:
-                        gitignorefile.writelines(Commiter.translatejazzignore(jazzignorelines))
+                path = repositoryfile[0:len(repositoryfile)-jazzignorelen]
+                gitignore = path + ".gitignore"
+                if os.path.exists(repositoryfile):
+                    # update (or create) .gitignore
+                    jazzignorelines = []
+                    with open(repositoryfile, 'r') as jazzignorefile:
+                        jazzignorelines = jazzignorefile.readlines()
+                    if len(jazzignorelines) > 0:
+                        # overwrite in any case
+                        with open(gitignore, 'w') as gitignorefile:
+                            gitignorefile.writelines(Commiter.translatejazzignore(jazzignorelines))
+                else:
+                    # delete .gitignore
+                    if os.path.exists(gitignore):
+                        os.remove(gitignore)
 
 
 class Differ:

--- a/migration.py
+++ b/migration.py
@@ -88,9 +88,8 @@ def migrate():
         git.promotebranchtomaster(streamname)
 
     RTCLogin.logout()
-    shouter.shout("\nAll changes accepted - Migration of stream '%s' is completed. \n"
-                  "You should adjust your .gitignore to ignore the same files as defined in your .jazzignore \n"
-                  "Afterwards you can distribute the git-repo '%s'" % (streamname, config.gitRepoName))
+    shouter.shout("\nAll changes accepted - Migration of stream '%s' is completed.\n"
+                  "You can distribute the git-repo '%s'." % (streamname, config.gitRepoName))
 
 
 def prepare():

--- a/tests/resources/test_.gitignore
+++ b/tests/resources/test_.gitignore
@@ -1,0 +1,13 @@
+
+*.class
+*.so
+*.pyc
+
+/*.suo
+/.classpath
+/.idea
+/.project
+/.settings
+/bin
+/dist
+/a?c

--- a/tests/resources/test_.jazzignore
+++ b/tests/resources/test_.jazzignore
@@ -1,0 +1,37 @@
+### Jazz Ignore 0
+# Ignored files and folders will not be committed, but may be modified during
+# accept or update.
+# - Ignore properties should contain a space separated list of filename patterns.
+# - Each pattern is case sensitive and surrounded by braces ('{' and '}').
+# - "*" matches zero or more characters.
+# - "?" matches a single character.
+# - The pattern list may be split across lines by ending the line with a
+#     backslash and starting the next line with a tab.
+# - Patterns in core.ignore prevent matching resources in the same
+#     directory from being committed.
+# - Patterns in core.ignore.recursive matching resources in the current
+#     directory and all subdirectories from being committed.
+# - The default value of core.ignore.recursive is *.class
+# - The default value for core.ignore is bin
+#
+# To ignore shell scripts and hidden files in this subtree:
+#     e.g: core.ignore.recursive = {*.sh} {\.*}
+#
+# To ignore resources named 'bin' in the current directory (but allow
+#  them in any sub directorybelow):
+#     e.g: core.ignore.recursive = {*.sh} {\.*}
+#
+# NOTE: modifying ignore files will not change the ignore status of
+#     Eclipse derived resources.
+
+core.ignore.recursive = {*.class} {*.so} \
+	{*.pyc}
+
+core.ignore = {*.suo} {.classpath} \
+	{.idea} \
+	{.project} \
+	{.settings} \
+	{bin} \
+	{dist} \
+	{a?c}
+

--- a/tests/test_gitFunctions.py
+++ b/tests/test_gitFunctions.py
@@ -231,6 +231,14 @@ class GitFunctionsTestCase(unittest.TestCase):
             Commiter.addandcommit(testhelper.createchangeentry(comment="Check out \"" + ">" + "\"US3333\""))
             self.assertEqual(0, len(shell.getoutput("git status -z")), "No file should be created by commit message")
 
+    def test_translatejazzignore(self):
+        with open(testhelper.getrelativefilename('./resources/test_.jazzignore'), 'r') as jazzignore:
+            inputlines = jazzignore.readlines()
+        with open(testhelper.getrelativefilename('./resources/test_.gitignore'), 'r') as gitignore:
+            expectedlines = gitignore.readlines()
+        self.assertEqual(expectedlines, Commiter.translatejazzignore(inputlines))
+
+
     def simulateCreationAndRenameInGitRepo(self, originalfilename, newfilename):
         open(originalfilename, 'a').close()  # create file
         Initializer.initialcommit()


### PR DESCRIPTION
Keep all the `.jazzignore` files in sync with `.gitignore` files at the same location.
Fixes #66