### PR TITLE
Make sure ignored file names are not recursive

### DIFF
--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -320,6 +320,8 @@ class ExtensionFilter:
                 extlen = len(extension)
                 if len(repositoryfile) >= extlen:
                     if repositoryfile[-extlen:] == extension:
-                        # escape a backslash with a backslash, and append a newline
-                        repositoryfilestoignore.append(repositoryfile.replace('\\', '\\\\') + os.linesep)
+                        # prepend a forward slash (for non recursive,)
+                        # escape a backslash with a backslash
+                        # append a newline
+                        repositoryfilestoignore.append('/' + repositoryfile.replace('\\', '\\\\') + os.linesep)
         return repositoryfilestoignore

--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -29,6 +29,7 @@ class Initializer:
                     ignore.write(newline + "# directories" + newline)
                     for directory in config.ignoredirectories:
                         ignore.write('/' + directory + newline)
+                    ignore.write(newline)
             shell.execute("git add " + git_ignore)
             shell.execute("git commit -m %s -q" % shell.quote("Add .gitignore"))
 

--- a/tests/test_gitFunctions.py
+++ b/tests/test_gitFunctions.py
@@ -101,6 +101,7 @@ class GitFunctionsTestCase(unittest.TestCase):
             expectedlines.append("# directories\n")
             expectedlines.append("/projectX/dist\n")
             expectedlines.append("/projectZ/out\n")
+            expectedlines.append("\n")
             with open(gitignorepath, 'r') as gitignore:
                 lines = gitignore.readlines()
                 self.assertEqual(expectedlines, lines)

--- a/tests/test_gitFunctions.py
+++ b/tests/test_gitFunctions.py
@@ -223,8 +223,9 @@ class GitFunctionsTestCase(unittest.TestCase):
                 lines = gitIgnore.readlines()
                 self.assertEqual(2, len(lines))
                 lines.sort()
-                self.assertEqual(jar, lines[0].strip())
-                self.assertEqual(zip, lines[1].strip())
+                # the ignore should not be recursive:
+                self.assertEqual('/' + jar, lines[0].strip())
+                self.assertEqual('/' + zip, lines[1].strip())
 
     def test_handleignore_local_jazzignore_expect_new_gitignore(self):
         with testhelper.mkchdir("aFolder") as folder:


### PR DESCRIPTION
Prepend the single lines with a forward `/`.
Fixes #81 