### PR TITLE
[fix] Add quotes for Password string since it may contain special chars.

### DIFF
--- a/rtcFunctions.py
+++ b/rtcFunctions.py
@@ -28,7 +28,7 @@ class RTCLogin:
     @staticmethod
     def loginandcollectstreamuuid():
         config = configuration.get()
-        shell.execute("%s login -r %s -u %s -P %s" % (config.scmcommand, config.repo, config.user, config.password))
+        shell.execute("%s login -r %s -u '%s' -P '%s'" % (config.scmcommand, config.repo, config.user, config.password))
         config.collectstreamuuids()
 
     @staticmethod
@@ -187,7 +187,7 @@ class ImportHandler:
         for entry in componentbaselinesentries:
             shouter.shout("Determine initial baseline of " + entry.componentname)
             # use always scm, lscm fails when specifying maximum over 10k
-            command = "scm --show-alias n --show-uuid y list baselines --components %s -r %s -u %s -P %s -m 20000" % \
+            command = "scm --show-alias n --show-uuid y list baselines --components %s -r %s -u %s -P '%s' -m 20000" % \
                       (entry.component, config.repo, config.user, config.password)
             baselineslines = shell.getoutput(command)
             baselineslines.reverse()  # reverse to have earliest baseline on top


### PR DESCRIPTION
When a password contains a special character like `#`, the login function can fail as it tries to terminate the current expression.