### PR TITLE
Replace custom quote function with shlex.quote

### DIFF
--- a/gitFunctions.py
+++ b/gitFunctions.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from datetime import datetime
 import re
 
@@ -31,7 +32,7 @@ class Initializer:
                         ignore.write('/' + directory + newline)
                     ignore.write(newline)
             shell.execute("git add " + git_ignore)
-            shell.execute("git commit -m %s -q" % shell.quote("Add .gitignore"))
+            shell.execute("git commit -m %s -q" % shlex.quote("Add .gitignore"))
 
     @staticmethod
     def createattributes():
@@ -47,7 +48,7 @@ class Initializer:
                     for line in config.gitattributes:
                         attributes.write(line + newline)
                 shell.execute("git add " + gitattribues)
-                shell.execute("git commit -m %s -q" % shell.quote("Add .gitattributes"))
+                shell.execute("git commit -m %s -q" % shlex.quote("Add .gitattributes"))
 
     def initalize(self):
         self.createrepo()
@@ -76,7 +77,7 @@ class Initializer:
         shouter.shout("Initial git add")
         shell.execute("git add -A", os.devnull)
         shouter.shout("Finished initial git add, starting commit")
-        shell.execute("git commit -m %s -q" % shell.quote("Initial Commit"))
+        shell.execute("git commit -m %s -q" % shlex.quote("Initial Commit"))
         shouter.shout("Finished initial commit")
 
 
@@ -123,7 +124,7 @@ class Commiter:
     def getcommitcommand(changeentry):
         comment = Commiter.getcommentwithprefix(changeentry.comment)
         return "git commit -m %s --date %s --author=%s" \
-               % (shell.quote(comment), shell.quote(changeentry.date), changeentry.getgitauthor())
+               % (shlex.quote(comment), shlex.quote(changeentry.date), changeentry.getgitauthor())
 
     @staticmethod
     def getcommentwithprefix(comment):
@@ -135,7 +136,7 @@ class Commiter:
 
     @staticmethod
     def replaceauthor(author, email):
-        shell.execute("git config --replace-all user.name " + shell.quote(author))
+        shell.execute("git config --replace-all user.name " + shlex.quote(author))
         shell.execute("git config --replace-all user.email " + email)
 
     @staticmethod

--- a/rtcFunctions.py
+++ b/rtcFunctions.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import re
+import shlex
 from enum import Enum, unique
 
 import configuration
@@ -93,7 +94,7 @@ class WorkspaceHandler:
 
 
 class Changes:
-    
+
     latest_accept_command = ""
 
     @staticmethod
@@ -420,7 +421,7 @@ class ChangeEntry:
 
     def getgitauthor(self):
         authorrepresentation = "%s <%s>" % (self.author, self.email)
-        return shell.quote(authorrepresentation)
+        return shlex.quote(authorrepresentation)
 
     def setAccepted(self):
         self.accepted = True

--- a/shell.py
+++ b/shell.py
@@ -2,6 +2,7 @@ import sys
 from subprocess import call, check_output, CalledProcessError
 
 import shouter
+import shlex
 
 logcommands = False
 encoding = None
@@ -35,15 +36,9 @@ def getoutput(command, stripped=True):
         return lines
 
 
-def quote(stringtoquote):
-    stringtoquote = stringtoquote.replace('\"', "'")  # replace " with '
-    quotedstring = '\"' + stringtoquote + '\"'
-    return quotedstring
-
-
 def shout_command_to_log(command, outputfile=None):
     if logcommands:
-        logmessage = "Executed Command: " + quote(command)
+        logmessage = "Executed Command: " + shlex.quote(command)
         if outputfile:
             shouter.shout(logmessage + " --> " + outputfile)
         else:


### PR DESCRIPTION
The custom written `shell.quote` function was causing issues with it not
correctly escaping some characters. As Python 3.3+ comes with a `quote`
function in the `shlex` module, we use that in place of the custom
`quote` function.

Fixes issue #97.